### PR TITLE
feat(dashboard): redesign as continuous improvement experiment report

### DIFF
--- a/docs/brainstorms/2026-02-08-dashboard-redesign-brainstorm.md
+++ b/docs/brainstorms/2026-02-08-dashboard-redesign-brainstorm.md
@@ -1,0 +1,130 @@
+# Dashboard Redesign: From Monitoring Tool to Experiment Report
+
+**Date**: 2026-02-08
+**Status**: Brainstorm complete, ready for planning
+
+## What We're Building
+
+A complete redesign of the Streamlit dashboard from a live monitoring tool into an **experiment report** that tells the story of one clean run-through of the ML pipeline.
+
+### The Narrative
+
+> "I built an MLOps system that detects data drift and automatically retrains models. I fed 5 batches of data through it. Here's what happened."
+
+The dashboard should read like a finished experiment — a vertical scrollable story showing the initial baseline, then each batch's drift analysis, retraining decision, and model performance.
+
+## Why This Approach
+
+**Problem**: The current dashboard shows every historical MLflow run — dozens of debug runs, repeated batch triggers, noise from development. It's built as a live ops console when it should be a portfolio demonstration.
+
+**Solution**: Filter to the **latest run per batch number** and redesign the layout as a linear story.
+
+- No pipeline changes needed (just add a baseline step)
+- No MLflow cleanup needed (filtering handles historical noise)
+- Re-running any batch automatically updates the dashboard
+- Simple, minimal, YAGNI-compliant
+
+## Key Decisions
+
+### 1. Data Filtering Strategy
+**Decision**: Latest per batch (Approach 1)
+- Dashboard queries MLflow, groups by `batch_number` param, takes most recent run per batch
+- Works for both drift monitoring experiment and training experiment
+- No session IDs, no experiment isolation, no pipeline changes
+
+### 2. Dashboard Layout
+**Decision**: Vertical scroll story
+- NOT tabs — one continuous scrollable page
+- Each batch gets a full-width section
+- Reads like a data science report or portfolio case study
+
+### 3. Baseline Display
+**Decision**: Show "Batch 0" as starting point
+- Need to create a baseline capture step (script or DAG task)
+- Evaluates initial model on initial_test data
+- Logs as quality gate run with `batch_number=0`, `decision='BASELINE'`
+- Shows initial AUC, F1, precision, recall as the starting point
+
+### 4. Metrics Per Batch
+**Decision**: Show production model metrics for every batch; show new model metrics where retraining occurred
+- Batches without retraining: production model metrics only
+- Batches with retraining: both production and new model metrics side-by-side
+- Metrics: AUC, F1, precision, recall
+
+### 5. Drift Visualization
+**Decision**: Integrated into the journey view
+- Each batch section shows its drift score
+- Clear threshold line (0.30) marking retrain/no-retrain boundary
+- Color-coded: green = below threshold (no retrain), red = above threshold (retrain triggered)
+- Also a summary chart showing drift progression across all batches
+
+### 6. Pipeline Trigger Model
+**Decision**: Keep separate per-batch triggers
+- Each batch is triggered individually (as today)
+- Dashboard identifies "latest run-through" by taking most recent run per batch
+- No session grouping needed
+
+## Dashboard Section Outline
+
+### Section 1: Hero / Overview
+- Project title and one-line description
+- Current production model version and stage
+- Summary stats: total batches processed, models trained, current AUC
+
+### Section 2: Experiment Summary
+- **Drift Progression Chart**: Bar chart showing drift_share for batches 0-5, with 0.30 threshold line
+- **Metrics Summary Table**: One row per batch, columns for:
+  - Batch number
+  - Drift share
+  - Retrain triggered? (Yes/No)
+  - Production model AUC, F1, precision, recall
+  - New model AUC, F1, precision, recall (if retrained)
+  - Decision (BASELINE / SKIP_NO_DRIFT / DEPLOY / SKIP)
+
+### Section 3: The Journey (per-batch sections)
+For each batch (0 through 5), a full-width section containing:
+
+**Batch 0 (Baseline)**:
+- "Initial model trained on initial dataset"
+- Baseline metrics: AUC, F1, precision, recall
+- No drift analysis (this is the starting point)
+
+**Batches 1-5** (each):
+- Batch header with drift score and retrain decision badge
+- Drift details: drift_share, number of drifted features, dataset_drift flag
+- Model performance:
+  - Production model metrics on this batch's test data
+  - If retrained: new model metrics + improvement deltas
+- Optional: ROC curve visualization (expandable)
+
+### Section 4: Final Summary
+- Starting AUC (Batch 0) vs. ending AUC (latest production model)
+- Total retraining events
+- Key takeaway: "The system detected drift in X of 5 batches and retrained Y times, improving AUC from A to B"
+
+## What Needs to Change
+
+### 1. New: Baseline Capture Script
+- Script that evaluates the initial production model on initial_test data
+- Logs a quality gate run to MLflow with batch_number=0
+- Run once before starting the batch sequence
+
+### 2. Dashboard: Complete Rewrite
+- Replace current 4-tab monitoring dashboard with vertical scroll story
+- New data loading: filter to latest run per batch
+- New visualizations: drift progression chart, metrics table, per-batch journey sections
+
+### 3. Pipeline: No Changes
+- DAG stays the same
+- MLflow logging stays the same (already logs batch_number consistently)
+- Batch creation stays the same
+
+## Open Questions
+
+1. **Should the dashboard have an "About" or methodology section?** (explaining how drift detection works, what the threshold means, etc.) — could be useful for portfolio context
+2. **ROC curves**: Include per-batch or just in a summary? The data is already logged.
+3. **Exact batch drift outcomes**: Need to verify that batches 1-2 don't trigger retraining and batches 3-5 do with the current 0.30 threshold (from memory: batch 1 ~0.27, batch 2 ~0.27, batch 3 ~0.32, batch 4 ~0.34, batch 5 ~0.35)
+
+## Next Steps
+
+Run `/workflows:plan` to create the implementation plan.

--- a/docs/plans/2026-02-08-feat-dashboard-experiment-report-redesign-plan.md
+++ b/docs/plans/2026-02-08-feat-dashboard-experiment-report-redesign-plan.md
@@ -1,0 +1,325 @@
+---
+title: "feat: Redesign dashboard as experiment report"
+type: feat
+date: 2026-02-08
+---
+
+# feat: Redesign Dashboard as Experiment Report
+
+## Overview
+
+Rewrite the Streamlit dashboard from a live monitoring tool into an **experiment report** — a vertical scrollable story showing one clean run-through of batches 0-5. Add a baseline capture step (Batch 0) so the report starts with initial model metrics.
+
+## Problem Statement / Motivation
+
+The current dashboard (`scripts/drift_dashboard.py`) shows every historical MLflow run — dozens of debug runs, repeated batch triggers, development noise. It's built as a live ops console (4 tabs, all runs) when it should be a **portfolio demonstration** that tells the story: "I built this system, fed 5 batches through it, here's what happened."
+
+**Specific issues:**
+- Dashboard queries ALL runs with no dedup — shows batch 1 run 7 times, batch 3 run 18 times
+- No baseline (Batch 0) showing initial model performance
+- Tab-based layout fragments the narrative instead of telling a linear story
+- Metrics are scattered across tabs instead of in one clear table
+
+## Proposed Solution
+
+### Phase 1: Baseline Capture Script
+
+Create `scripts/create_baseline.py` that establishes "Batch 0" — the starting point of the experiment.
+
+**What it does:**
+1. Load the current Production model from MLflow registry (`HealthPredictModel/Production`)
+2. Load the preprocessor from the model's training run artifacts
+3. Load `initial_test.csv` from S3 (`processed_data/initial_test.csv`)
+4. Apply feature engineering: `clean_data()` → `engineer_features()` → `preprocess_data()`
+5. Predict and compute metrics: AUC, F1, precision, recall
+6. Compute ROC curve
+7. Log a quality gate run to MLflow matching the existing format:
+   - Experiment: `HealthPredict_Training_HPO_Airflow`
+   - Run name: `quality_gate_batch_0`
+   - Params: `batch_number=0`, `test_set_used=initial_test`, `model_type=XGBoost`
+   - Metrics: `new_auc_test`, `new_f1_test`, `new_precision_test`, `new_recall_test` (all set to prod model values)
+   - Also: `prod_auc_test`, `prod_f1_test`, `prod_precision_test`, `prod_recall_test` (same values)
+   - `auc_improvement=0.0`, `f1_improvement=0.0`
+   - Tag: `quality_gate='True'`, `decision='BASELINE'`
+   - Artifact: `roc_curves/roc_curve_production.json`
+8. Also log a drift monitoring run for Batch 0:
+   - Experiment: `HealthPredict_Drift_Monitoring`
+   - Run name: `drift_batch_0`
+   - Params: `batch_number=0`
+   - Metrics: `drift_share=0.0`, `n_drifted_columns=0`, `dataset_drift=0`
+   - (Baseline has no drift by definition)
+
+**Key constraint:** Must match the exact MLflow logging format used by the DAG's `compare_against_production` and `evaluate_production_only` tasks so the dashboard can query it identically.
+
+**File:** `scripts/create_baseline.py`
+
+**Dependencies:** Same as DAG (mlflow, pandas, scikit-learn, xgboost, boto3) — already in `scripts/requirements-training.txt`
+
+**Run command:**
+```bash
+python scripts/create_baseline.py \
+  --s3-bucket-name health-predict-mlops-f9ac6509 \
+  --mlflow-tracking-uri http://localhost:5000
+```
+
+Or from inside a container:
+```bash
+docker exec mlops-services-airflow-scheduler-1 \
+  python /opt/airflow/scripts/create_baseline.py \
+  --s3-bucket-name health-predict-mlops-f9ac6509 \
+  --mlflow-tracking-uri http://mlflow:5000
+```
+
+### Phase 2: Dashboard Rewrite
+
+Complete rewrite of `scripts/drift_dashboard.py` — same file, new content.
+
+#### Data Loading Changes
+
+**Current:** Queries all runs, no dedup
+```python
+mlflow.search_runs(experiment_ids=[...], order_by=["start_time DESC"], max_results=100)
+```
+
+**New:** Query all runs, then deduplicate to latest per batch
+```python
+runs = mlflow.search_runs(...)
+# Group by batch_number param, keep most recent run per batch
+runs['batch'] = pd.to_numeric(runs['params.batch_number'], errors='coerce')
+latest_runs = runs.sort_values('start_time', ascending=False).drop_duplicates(subset=['batch'], keep='first')
+latest_runs = latest_runs.sort_values('batch')
+```
+
+This applies to BOTH experiments:
+- `HealthPredict_Drift_Monitoring` → latest drift run per batch
+- `HealthPredict_Training_HPO_Airflow` (quality gate filter) → latest quality gate per batch
+
+#### Page Layout: Vertical Scroll Story
+
+Replace the 4-tab structure with a single scrollable page:
+
+```
+┌─────────────────────────────────────────────┐
+│  HERO: Project Title + Summary Stats        │
+│  (Production model, total batches, AUC)     │
+├─────────────────────────────────────────────┤
+│  EXPERIMENT SUMMARY                         │
+│  ┌─────────────────────────────────────┐    │
+│  │ Drift Progression Chart             │    │
+│  │ (bar chart, 0-5, threshold line)    │    │
+│  └─────────────────────────────────────┘    │
+│  ┌─────────────────────────────────────┐    │
+│  │ Metrics Summary Table               │    │
+│  │ Batch | Drift | Retrain? | AUC | F1 │    │
+│  │   0   |  0.00 |    --    | .82 | .74│    │
+│  │   1   |  .27  |    No    | .82 | .74│    │
+│  │   2   |  .27  |    No    | .82 | .74│    │
+│  │   3   |  .32  |   Yes    | .84 | .76│    │
+│  │   4   |  .34  |   Yes    | .85 | .77│    │
+│  │   5   |  .35  |   Yes    | .83 | .75│    │
+│  └─────────────────────────────────────┘    │
+├─────────────────────────────────────────────┤
+│  BATCH 0: BASELINE                          │
+│  Initial model trained on initial dataset   │
+│  Metrics: AUC .82 | F1 .74 | Prec .71 ...  │
+├─────────────────────────────────────────────┤
+│  BATCH 1: No Drift Detected                │
+│  Drift: 0.27 (below 0.30 threshold)        │
+│  Decision: SKIP — no retraining             │
+│  Prod model on batch 1: AUC .82 | F1 .74   │
+├─────────────────────────────────────────────┤
+│  BATCH 2: No Drift Detected                │
+│  ...                                        │
+├─────────────────────────────────────────────┤
+│  BATCH 3: DRIFT DETECTED → RETRAINED       │
+│  Drift: 0.32 (above 0.30 threshold)        │
+│  Decision: DEPLOY                           │
+│  Prod model:  AUC .82 | F1 .74             │
+│  New model:   AUC .84 | F1 .76  (+0.02)    │
+│  [expandable ROC curve]                     │
+├─────────────────────────────────────────────┤
+│  BATCH 4: DRIFT DETECTED → RETRAINED       │
+│  ...                                        │
+├─────────────────────────────────────────────┤
+│  BATCH 5: DRIFT DETECTED → RETRAINED       │
+│  ...                                        │
+├─────────────────────────────────────────────┤
+│  FINAL SUMMARY                              │
+│  Starting AUC → Ending AUC                  │
+│  X of 5 batches triggered retraining        │
+│  Key takeaway sentence                      │
+└─────────────────────────────────────────────┘
+```
+
+#### Section Details
+
+**1. Hero Section**
+- Title: "Health Predict — Continuous Improvement Experiment"
+- 3 metric cards: Current Production Model (version + AUC), Batches Processed, Retraining Events
+- One-line description of the system
+
+**2. Experiment Summary**
+- **Drift Progression Chart** (Plotly bar chart):
+  - X-axis: Batch number (0-5)
+  - Y-axis: Drift share (0.0-1.0)
+  - Horizontal line at 0.30 threshold
+  - Color: green if < 0.30, red if >= 0.30
+  - Batch 0 bar = 0.0 (baseline, no drift)
+- **Metrics Summary Table** (Streamlit dataframe or custom HTML):
+  - Columns: Batch, Drift Share, Retrained?, Decision, Prod AUC, Prod F1, Prod Precision, Prod Recall, New AUC, New F1, New Precision, New Recall
+  - Retrained batches show both prod and new model metrics
+  - Non-retrained batches show prod metrics only, new columns blank or "—"
+  - Batch 0 shows baseline metrics, Retrained = "—"
+
+**3. Per-Batch Journey Sections**
+Each batch gets a `st.container()` with:
+- **Header**: "Batch N" + badge (color-coded: green "No Drift", red "Drift Detected → Retrained", blue "Baseline")
+- **Drift info**: drift_share value, n_drifted_columns, threshold comparison
+- **Decision**: What happened (BASELINE / SKIP_NO_DRIFT / DEPLOY / DEPLOY_REFRESH / SKIP)
+- **Metrics cards**: Production model metrics (always), New model metrics + deltas (if retrained)
+- **ROC Curve** (expandable `st.expander`): Load from MLflow artifacts if available
+
+**Batch 0 special case:**
+- No drift section (baseline by definition)
+- Show only production model metrics
+- Label as "Initial Training — Baseline"
+
+**4. Final Summary**
+- Starting AUC (Batch 0) → Final AUC (latest production model)
+- Count of retraining events
+- One-sentence takeaway
+
+#### Sidebar (Simplified)
+
+Keep minimal:
+- MLflow URI (auto from env var, rarely changed)
+- API URL (auto from env var)
+- "Refresh Data" button (clears cache)
+- Link to MLflow UI, Airflow UI
+
+### Phase 3: Rebuild & Verify
+
+1. Rebuild dashboard container: `docker-compose up -d --no-deps --build dashboard`
+2. Run baseline script to create Batch 0
+3. Run all 5 batches through the pipeline (or verify existing latest runs are clean)
+4. Verify dashboard shows the complete story
+
+## Technical Considerations
+
+### MLflow Query: "Latest Per Batch" Logic
+
+```python
+def get_latest_per_batch(experiment_name, filter_string=None):
+    """Query MLflow and return only the most recent run per batch number."""
+    experiment = mlflow.get_experiment_by_name(experiment_name)
+    if not experiment:
+        return pd.DataFrame()
+
+    runs = mlflow.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        filter_string=filter_string,
+        order_by=["start_time DESC"],
+        max_results=100,
+    )
+
+    if runs.empty:
+        return runs
+
+    # Extract batch number, deduplicate
+    runs['batch'] = pd.to_numeric(runs.get('params.batch_number', pd.Series()), errors='coerce')
+    runs = runs.dropna(subset=['batch'])
+    runs = runs.sort_values('start_time', ascending=False).drop_duplicates(subset=['batch'], keep='first')
+    return runs.sort_values('batch')
+```
+
+### Drift Monitoring Query
+```python
+drift_runs = get_latest_per_batch("HealthPredict_Drift_Monitoring")
+```
+
+### Quality Gate Query
+```python
+quality_runs = get_latest_per_batch(
+    "HealthPredict_Training_HPO_Airflow",
+    filter_string="metrics.new_auc_test > 0"
+)
+```
+
+### Decision Tag Extraction
+Quality gate runs have a `tags.decision` field:
+- `BASELINE` — Batch 0
+- `SKIP_NO_DRIFT` — No drift, prod model evaluated only
+- `DEPLOY` — Drift detected, new model deployed (improvement)
+- `DEPLOY_REFRESH` — Drift detected, minor regression but still deployed
+- `SKIP` — Drift detected, regression too large, deployment skipped
+
+### Docker Rebuild Safety
+Per CLAUDE.md: **Always use `--no-deps`** to avoid ContainerConfig bug:
+```bash
+cd /home/ubuntu/health-predict/mlops-services
+docker-compose up -d --no-deps --build dashboard
+```
+
+### ROC Curve Artifacts
+Stored as JSON in `roc_curves/` artifact folder. Load via:
+```python
+client = MlflowClient()
+artifact_path = client.download_artifacts(run_id, "roc_curves/roc_curve_new.json", "/tmp")
+with open(artifact_path) as f:
+    roc_data = json.load(f)  # {fpr: [...], tpr: [...], auc: float}
+```
+
+## Acceptance Criteria
+
+- [x] `scripts/create_baseline.py` creates a Batch 0 quality gate run in MLflow matching the existing format
+- [x] `scripts/create_baseline.py` creates a Batch 0 drift run (drift_share=0.0) in MLflow
+- [x] Dashboard shows exactly ONE run per batch (latest), not historical duplicates
+- [x] Dashboard is a single scrollable page (no tabs)
+- [x] Hero section shows project summary and current production model
+- [x] Drift progression chart shows batches 0-5 with 0.30 threshold line
+- [x] Metrics summary table shows AUC, F1, precision, recall for every batch
+- [x] Metrics table shows both prod and new model metrics for retrained batches
+- [x] Per-batch sections show drift info, decision, and metrics
+- [x] ROC curves are viewable per batch (expandable)
+- [x] Final summary shows starting vs ending AUC and retraining count
+- [x] Dashboard container rebuilds cleanly with `docker-compose up -d --no-deps --build dashboard`
+
+## Success Metrics
+
+- Dashboard tells a clear, linear story readable by someone unfamiliar with the project
+- No duplicate/noisy historical runs visible
+- All 6 batches (0-5) visible with complete metrics
+- Batches 1-2 show no retraining; batches 3-5 show retraining (matching expected drift profiles)
+
+## Dependencies & Risks
+
+**Dependencies:**
+- Production model must exist in MLflow registry before running baseline script
+- All 5 batches must have been run at least once (or re-run after baseline)
+- MLflow and S3 must be accessible
+
+**Risks:**
+- If batch drift profiles have shifted (e.g., batch 2 now drifts), the story changes — verify expected outcomes
+- Historical runs with `batch_number=0` could exist — baseline script should handle gracefully (latest-per-batch dedup handles this)
+- ROC curve artifacts may not exist for older runs — dashboard should handle missing artifacts gracefully
+
+## References & Research
+
+### Internal References
+- Current dashboard: `scripts/drift_dashboard.py` (792 lines, full rewrite)
+- Quality gate logging (retrain): DAG lines 698-745
+- Quality gate logging (prod-only): DAG lines 965-1005
+- Feature engineering: `src/feature_engineering.py` (clean_data, engineer_features, preprocess_data)
+- Training script: `scripts/train_model.py` (MLflow logging patterns)
+- Docker setup: `mlops-services/Dockerfile.dashboard`, `mlops-services/docker-compose.yml` lines 222-236
+- Dashboard deps: `scripts/requirements-dashboard.txt`
+
+### Brainstorm
+- `docs/brainstorms/2026-02-08-dashboard-redesign-brainstorm.md`
+
+## Implementation Order
+
+1. **Create baseline script** (`scripts/create_baseline.py`) — ~100 lines
+2. **Rewrite dashboard** (`scripts/drift_dashboard.py`) — ~400-500 lines (down from 792, simpler without 4 tabs)
+3. **Rebuild container** and run baseline
+4. **Run batches 1-5** (or verify existing runs) and confirm dashboard

--- a/mlops-services/dags/health_predict_continuous_improvement.py
+++ b/mlops-services/dags/health_predict_continuous_improvement.py
@@ -230,8 +230,8 @@ def drift_decision_branch(**kwargs):
         logging.info(f"DECISION: RETRAIN ({reason})")
         return 'prepare_drift_aware_data'
     else:
-        logging.info(f"DECISION: SKIP RETRAINING (no drift, drift_share={drift_share:.3f})")
-        return 'log_no_drift_skip'
+        logging.info(f"DECISION: EVALUATE PRODUCTION ONLY (no drift, drift_share={drift_share:.3f})")
+        return 'evaluate_production_only'
 
 drift_decision_branch_task = BranchPythonOperator(
     task_id='drift_decision_branch',
@@ -306,8 +306,8 @@ def prepare_drift_aware_data(**kwargs):
     
     # 5. Load all previous batches for cumulative training
     cumulative_data = [initial_train, initial_val]
-    
-    for prev_batch in range(2, batch_number):
+
+    for prev_batch in range(1, batch_number):
         prev_batch_key = f'drift_monitoring/batch_data/batch_{prev_batch}.csv'
         try:
             response = s3.get_object(Bucket=bucket, Key=prev_batch_key)
@@ -490,7 +490,8 @@ def compare_against_production(**kwargs):
     """
     Compare new model vs production on temporal test set using AUC
     """
-    from sklearn.metrics import roc_auc_score, precision_recall_fscore_support
+    from sklearn.metrics import roc_auc_score, precision_recall_fscore_support, roc_curve
+    import json
     
     ti = kwargs['ti']
     mlflow_uri = kwargs['params']['mlflow_uri']
@@ -642,7 +643,10 @@ def compare_against_production(**kwargs):
     )
     
     logging.info(f"New Model - AUC: {new_auc:.3f}, F1: {new_f1:.3f}, Precision: {new_precision:.3f}, Recall: {new_recall:.3f}")
-    
+
+    # Calculate ROC curve for new model
+    fpr_new, tpr_new, thresholds_new = roc_curve(y_test, new_pred_proba)
+
     # 4. Evaluate production model (if exists)
     if has_production:
         # Align features for production model separately (may expect different features)
@@ -684,9 +688,13 @@ def compare_against_production(**kwargs):
         )
         
         logging.info(f"Prod Model - AUC: {prod_auc:.3f}, F1: {prod_f1:.3f}, Precision: {prod_precision:.3f}, Recall: {prod_recall:.3f}")
+
+        # Calculate ROC curve for production model
+        fpr_prod, tpr_prod, thresholds_prod = roc_curve(y_test, prod_pred_proba)
     else:
         prod_auc, prod_precision, prod_recall, prod_f1 = 0, 0, 0, 0
-    
+        fpr_prod, tpr_prod, thresholds_prod = None, None, None
+
     # 5. Log metrics to a dedicated quality gate run (separate from HPO training run)
     experiment_name = kwargs['params']['experiment_name']
     mlflow.set_experiment(experiment_name)
@@ -710,6 +718,28 @@ def compare_against_production(**kwargs):
 
                 mlflow.log_metric("auc_improvement", new_auc - prod_auc)
                 mlflow.log_metric("f1_improvement", new_f1 - prod_f1)
+
+            # Save ROC curve data as artifacts
+            roc_data_new = {
+                'fpr': fpr_new.tolist(),
+                'tpr': tpr_new.tolist(),
+                'thresholds': thresholds_new.tolist(),
+                'auc': new_auc,
+            }
+            with open('/tmp/roc_curve_new.json', 'w') as f:
+                json.dump(roc_data_new, f)
+            mlflow.log_artifact('/tmp/roc_curve_new.json', artifact_path='roc_curves')
+
+            if has_production and fpr_prod is not None:
+                roc_data_prod = {
+                    'fpr': fpr_prod.tolist(),
+                    'tpr': tpr_prod.tolist(),
+                    'thresholds': thresholds_prod.tolist(),
+                    'auc': prod_auc,
+                }
+                with open('/tmp/roc_curve_production.json', 'w') as f:
+                    json.dump(roc_data_prod, f)
+                mlflow.log_artifact('/tmp/roc_curve_production.json', artifact_path='roc_curves')
     except Exception as e:
         logging.warning(f"MLflow quality gate logging warning: {e}")
     
@@ -762,6 +792,235 @@ compare_against_production_task = PythonOperator(
         'regression_threshold': env_vars['REGRESSION_THRESHOLD'],
         'experiment_name': env_vars['EXPERIMENT_NAME']
     },
+    dag=dag,
+)
+
+# Task 4.5: Evaluate production model only (no retraining path)
+def evaluate_production_only(**kwargs):
+    """
+    Evaluate production model on current batch's test data without retraining.
+    Used when drift is below threshold - still want to track performance.
+    """
+    from sklearn.metrics import roc_auc_score, precision_recall_fscore_support, roc_curve
+    import json
+
+    # 1. Get batch_number from drift detection XCom
+    ti = kwargs['ti']
+    drift_result = ti.xcom_pull(task_ids='run_drift_detection')
+    batch_number = drift_result.get('batch_number', 'unknown') if drift_result else 'unknown'
+
+    logging.info(f"=== PRODUCTION-ONLY EVALUATION: Batch {batch_number} ===")
+
+    # 2. Load production model from MLflow registry
+    mlflow_uri = kwargs['params']['mlflow_uri']
+    mlflow.set_tracking_uri(mlflow_uri)
+
+    try:
+        prod_model = mlflow.sklearn.load_model("models:/HealthPredictModel/Production")
+        logging.info("Loaded production model from registry")
+    except Exception as e:
+        # No production model exists yet (e.g., batch 1 run before batch 3)
+        logging.warning(f"No production model found: {e}")
+        return {'has_metrics': False, 'reason': 'no_production_model', 'batch_number': batch_number}
+
+    # 3. Load or create batch test set (30% of batch data)
+    s3 = boto3.client('s3')
+    bucket = env_vars['S3_BUCKET_NAME']
+    test_key = f"drift_monitoring/test_data/batch_{batch_number}_test.csv"
+
+    try:
+        # Try to load existing test set
+        test_response = s3.get_object(Bucket=bucket, Key=test_key)
+        test_data = pd.read_csv(StringIO(test_response['Body'].read().decode('utf-8')))
+        logging.info(f"Loaded existing test set from {test_key}")
+    except Exception:
+        # Create test set from batch data (70/30 split, matching training pattern)
+        batch_key = f"drift_monitoring/batch_data/batch_{batch_number}.csv"
+        try:
+            batch_response = s3.get_object(Bucket=bucket, Key=batch_key)
+            batch_data = pd.read_csv(StringIO(batch_response['Body'].read().decode('utf-8')))
+
+            # Ensure readmitted_binary exists
+            if 'readmitted_binary' not in batch_data.columns and 'readmitted' in batch_data.columns:
+                batch_data['readmitted_binary'] = (batch_data['readmitted'] == '<30').astype(int)
+
+            _, test_data = train_test_split(
+                batch_data,
+                test_size=0.3,
+                random_state=42,
+                stratify=batch_data['readmitted_binary'] if 'readmitted_binary' in batch_data.columns else None
+            )
+
+            # Save for future use
+            test_csv = test_data.to_csv(index=False)
+            s3.put_object(Bucket=bucket, Key=test_key, Body=test_csv)
+            logging.info(f"Created and saved test set to {test_key}")
+        except Exception as e:
+            logging.error(f"Failed to create test set: {e}")
+            return {'has_metrics': False, 'reason': 'test_data_error', 'batch_number': batch_number}
+
+    # 4. Apply feature engineering (reuse from compare_against_production)
+    import sys
+    sys.path.insert(0, '/home/ubuntu/health-predict')
+    from src.feature_engineering import clean_data, engineer_features
+
+    test_data_clean = clean_data(test_data)
+    test_data_featured = engineer_features(test_data_clean)
+
+    logging.info(f"After feature engineering: {test_data_featured.shape}")
+
+    # 5. One-hot encode categoricals
+    cat_cols = test_data_featured.select_dtypes(include=['object']).columns.tolist()
+    cat_cols = [c for c in cat_cols if c not in ['readmitted_binary', 'readmitted']]
+
+    if cat_cols:
+        logging.info(f"One-hot encoding {len(cat_cols)} categorical columns")
+        test_data_encoded = pd.get_dummies(test_data_featured, columns=cat_cols, drop_first=True)
+    else:
+        test_data_encoded = test_data_featured
+
+    # 6. Prepare features
+    X_test = test_data_encoded.drop(columns=['readmitted_binary', 'readmitted', 'age'], errors='ignore')
+    y_test = test_data_featured['readmitted_binary']
+
+    # 7. Align features with production model (reuse alignment logic)
+    expected_features = None
+    if hasattr(prod_model, 'feature_names_in_') and prod_model.feature_names_in_ is not None:
+        expected_features = list(prod_model.feature_names_in_)
+        logging.info(f"Got {len(expected_features)} features from feature_names_in_")
+    elif hasattr(prod_model, 'get_booster'):
+        try:
+            booster = prod_model.get_booster()
+            if hasattr(booster, 'feature_names') and booster.feature_names is not None:
+                expected_features = list(booster.feature_names)
+                logging.info(f"Got {len(expected_features)} features from get_booster()")
+        except Exception as e:
+            logging.warning(f"Failed to get feature names from get_booster(): {e}")
+
+    if expected_features is not None:
+        logging.info(f"Aligning features: model expects {len(expected_features)}, test data has {len(X_test.columns)}")
+
+        # Add missing columns with zeros
+        missing_cols = set(expected_features) - set(X_test.columns)
+        if missing_cols:
+            logging.info(f"Adding {len(missing_cols)} missing columns with zeros")
+            for col in missing_cols:
+                X_test[col] = 0
+
+        # Remove extra columns
+        extra_cols = set(X_test.columns) - set(expected_features)
+        if extra_cols:
+            logging.info(f"Removing {len(extra_cols)} extra columns")
+            X_test = X_test.drop(columns=list(extra_cols))
+
+        # Reorder columns to match model's expected order
+        X_test = X_test[expected_features]
+        logging.info(f"Aligned test features: {X_test.shape}")
+
+    # 8. Evaluate production model
+    prod_pred_proba = prod_model.predict_proba(X_test)[:, 1]
+    prod_pred = (prod_pred_proba > 0.5).astype(int)
+
+    prod_auc = roc_auc_score(y_test, prod_pred_proba)
+    prod_precision, prod_recall, prod_f1, _ = precision_recall_fscore_support(
+        y_test, prod_pred, average='binary', zero_division=0
+    )
+
+    logging.info(f"Production Model - AUC: {prod_auc:.3f}, F1: {prod_f1:.3f}, Precision: {prod_precision:.3f}, Recall: {prod_recall:.3f}")
+
+    # Calculate ROC curve for visualization
+    fpr, tpr, thresholds = roc_curve(y_test, prod_pred_proba)
+
+    # 9. Log to MLflow as quality gate run
+    experiment_name = kwargs['params']['experiment_name']
+    mlflow.set_experiment(experiment_name)
+
+    try:
+        with mlflow.start_run(run_name=f"quality_gate_batch_{batch_number}") as run:
+            # Log params
+            mlflow.log_param("batch_number", batch_number)
+            mlflow.log_param("test_set_used", f"batch_{batch_number}_test")
+            mlflow.log_param("evaluation_type", "production_only")
+
+            # Tag as quality gate run
+            mlflow.set_tag("quality_gate", "True")
+            mlflow.set_tag("decision", "SKIP_NO_DRIFT")
+
+            # Log metrics (use new_* names so dashboard query finds them)
+            mlflow.log_metric("new_auc_test", prod_auc)
+            mlflow.log_metric("new_f1_test", prod_f1)
+            mlflow.log_metric("new_precision_test", prod_precision)
+            mlflow.log_metric("new_recall_test", prod_recall)
+
+            # Also log as prod_* for clarity
+            mlflow.log_metric("prod_auc_test", prod_auc)
+            mlflow.log_metric("prod_f1_test", prod_f1)
+            mlflow.log_metric("prod_precision_test", prod_precision)
+            mlflow.log_metric("prod_recall_test", prod_recall)
+
+            # Improvement is zero (same model)
+            mlflow.log_metric("auc_improvement", 0.0)
+            mlflow.log_metric("f1_improvement", 0.0)
+
+            # Save ROC curve data as artifact
+            roc_data = {
+                'fpr': fpr.tolist(),
+                'tpr': tpr.tolist(),
+                'thresholds': thresholds.tolist(),
+                'auc': prod_auc,
+            }
+            with open('/tmp/roc_curve_production.json', 'w') as f:
+                json.dump(roc_data, f)
+            mlflow.log_artifact('/tmp/roc_curve_production.json', artifact_path='roc_curves')
+
+            logging.info(f"Logged metrics to MLflow run: {run.info.run_id}")
+    except Exception as e:
+        logging.warning(f"MLflow logging failed: {e}")
+
+    return {
+        'has_metrics': True,
+        'batch_number': batch_number,
+        'prod_auc': prod_auc,
+        'prod_f1': prod_f1,
+        'decision': 'SKIP_NO_DRIFT'
+    }
+
+evaluate_production_only_task = PythonOperator(
+    task_id='evaluate_production_only',
+    python_callable=evaluate_production_only,
+    params={
+        'mlflow_uri': env_vars['MLFLOW_TRACKING_URI'],
+        'experiment_name': env_vars['EXPERIMENT_NAME'],
+    },
+    dag=dag,
+)
+
+# Task 4.6: Log completion of production-only evaluation
+def log_production_only_complete(**kwargs):
+    """Log completion of production-only evaluation path."""
+    ti = kwargs['ti']
+    result = ti.xcom_pull(task_ids='evaluate_production_only')
+
+    if not result or not result.get('has_metrics', False):
+        logging.info("=== PRODUCTION-ONLY EVALUATION SKIPPED ===")
+        logging.info(f"Reason: {result.get('reason', 'unknown') if result else 'unknown'}")
+        return {'status': 'skipped_no_production'}
+
+    batch_number = result.get('batch_number', 'unknown')
+    prod_auc = result.get('prod_auc', 0.0)
+    prod_f1 = result.get('prod_f1', 0.0)
+
+    logging.info("=== PRODUCTION-ONLY EVALUATION COMPLETE ===")
+    logging.info(f"Batch: {batch_number}")
+    logging.info(f"Production AUC: {prod_auc:.4f}")
+    logging.info(f"Production F1: {prod_f1:.4f}")
+    logging.info("Decision: SKIP_NO_DRIFT (no retraining needed)")
+
+    return {'status': 'completed', 'batch_number': batch_number}
+
+log_production_only_complete_task = PythonOperator(
+    task_id='log_production_only_complete',
+    python_callable=log_production_only_complete,
     dag=dag,
 )
 
@@ -1462,51 +1721,6 @@ notify_no_deployment_task = PythonOperator(
     dag=dag,
 )
 
-# Skip retraining path (no drift detected)
-def log_no_drift_skip(**kwargs):
-    """Log that retraining was skipped due to no drift detection."""
-    ti = kwargs['ti']
-    drift_result = ti.xcom_pull(task_ids='run_drift_detection')
-
-    logging.info("=== RETRAINING SKIPPED: NO DRIFT DETECTED ===")
-    logging.info(f"Batch: {drift_result.get('batch_number', 'unknown') if drift_result else 'unknown'}")
-    logging.info(f"Drift share: {drift_result.get('drift_share', 0):.3f}" if drift_result else "Drift share: N/A")
-    logging.info(f"Threshold: {env_vars['DRIFT_THRESHOLD']}")
-    logging.info(f"Drifted columns: {drift_result.get('n_drifted_columns', 0)}/{drift_result.get('n_total_columns', 0)}" if drift_result else "")
-    logging.info("Current production model maintained. No retraining needed.")
-    logging.info("=== END ===")
-
-    return {
-        "status": "skipped_no_drift",
-        "drift_result": drift_result
-    }
-
-log_no_drift_skip_task = PythonOperator(
-    task_id='log_no_drift_skip',
-    python_callable=log_no_drift_skip,
-    dag=dag,
-)
-
-def notify_no_drift(**kwargs):
-    """Send notification about skipped retraining due to no drift."""
-    ti = kwargs['ti']
-    skip_data = ti.xcom_pull(task_ids='log_no_drift_skip')
-
-    logging.info("=== NO DRIFT NOTIFICATION ===")
-    if skip_data and skip_data.get('drift_result'):
-        logging.info(f"Status: {skip_data['status']}")
-        logging.info(f"Drift share: {skip_data['drift_result'].get('drift_share', 0):.3f}")
-    logging.info("Production model unchanged. No retraining was triggered.")
-    logging.info("=== END ===")
-
-    return skip_data
-
-notify_no_drift_task = PythonOperator(
-    task_id='notify_no_drift',
-    python_callable=notify_no_drift,
-    dag=dag,
-)
-
 # End task (dummy operator for clean graph visualization)
 end_task = DummyOperator(
     task_id='end',
@@ -1633,5 +1847,5 @@ deployment_decision_branch_task >> check_kubernetes_readiness_task >> register_a
 # Skip deploy path (AUC regression detected)
 deployment_decision_branch_task >> log_skip_decision_task >> notify_no_deployment_task >> end_task
 
-# Skip retrain path (no drift detected)
-drift_decision_branch_task >> log_no_drift_skip_task >> notify_no_drift_task >> end_task 
+# Skip retrain path (no drift detected) - now routes to production-only evaluation
+drift_decision_branch_task >> evaluate_production_only_task >> log_production_only_complete_task >> end_task 

--- a/scripts/create_baseline.py
+++ b/scripts/create_baseline.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Create Baseline (Batch 0) — establishes the starting point for the experiment report.
+
+Evaluates the current production model on initial_test.csv and logs:
+  1. A quality gate run (HealthPredict_Training_HPO_Airflow) with batch_number=0
+  2. A drift monitoring run (HealthPredict_Drift_Monitoring) with batch_number=0, drift_share=0.0
+
+Usage:
+    python scripts/create_baseline.py \
+        --s3-bucket-name health-predict-mlops-f9ac6509 \
+        --mlflow-tracking-uri http://localhost:5000
+
+    # Or inside a container:
+    docker exec mlops-services-airflow-scheduler-1 \
+        python /opt/airflow/scripts/create_baseline.py \
+        --s3-bucket-name health-predict-mlops-f9ac6509 \
+        --mlflow-tracking-uri http://mlflow:5000
+"""
+
+import argparse
+import json
+import logging
+import sys
+import os
+
+import boto3
+import mlflow
+from mlflow.tracking import MlflowClient
+import pandas as pd
+import numpy as np
+from io import StringIO
+from sklearn.metrics import roc_auc_score, roc_curve, precision_recall_fscore_support
+
+# Allow import from project root
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from src.feature_engineering import clean_data, engineer_features
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+log = logging.getLogger(__name__)
+
+MODEL_NAME = "HealthPredictModel"
+TRAINING_EXPERIMENT = "HealthPredict_Training_HPO_Airflow"
+DRIFT_EXPERIMENT = "HealthPredict_Drift_Monitoring"
+
+
+def load_production_model(client: MlflowClient):
+    """Load the current Production model from the MLflow registry."""
+    versions = client.get_latest_versions(MODEL_NAME, stages=["Production"])
+    if not versions:
+        raise RuntimeError(f"No Production version found for model '{MODEL_NAME}'")
+    mv = versions[0]
+    log.info(f"Loading production model v{mv.version} (run {mv.run_id})")
+    model = mlflow.pyfunc.load_model(f"models:/{MODEL_NAME}/Production")
+    # Unwrap to get the raw sklearn/xgboost model for predict_proba
+    raw_model = model._model_impl.sklearn_model if hasattr(model._model_impl, 'sklearn_model') else model
+    return raw_model, mv
+
+
+def load_test_data(s3, bucket: str) -> pd.DataFrame:
+    """Load initial_test.csv from S3."""
+    key = "processed_data/initial_test.csv"
+    log.info(f"Loading test data from s3://{bucket}/{key}")
+    resp = s3.get_object(Bucket=bucket, Key=key)
+    return pd.read_csv(StringIO(resp['Body'].read().decode('utf-8')))
+
+
+def prepare_features(df: pd.DataFrame) -> tuple:
+    """Apply feature engineering and return (X, y)."""
+    df_clean = clean_data(df)
+    df_feat = engineer_features(df_clean)
+
+    # One-hot encode categoricals (matching DAG pattern)
+    cat_cols = df_feat.select_dtypes(include=['object']).columns.tolist()
+    cat_cols = [c for c in cat_cols if c not in ['readmitted_binary', 'readmitted']]
+    if cat_cols:
+        df_encoded = pd.get_dummies(df_feat, columns=cat_cols, drop_first=True)
+    else:
+        df_encoded = df_feat
+
+    X = df_encoded.drop(columns=['readmitted_binary', 'readmitted', 'age'], errors='ignore')
+    y = df_feat['readmitted_binary']
+    return X, y
+
+
+def align_features(X: pd.DataFrame, model) -> pd.DataFrame:
+    """Align test features to match what the production model expects."""
+    expected = None
+
+    if hasattr(model, 'feature_names_in_') and model.feature_names_in_ is not None:
+        expected = list(model.feature_names_in_)
+    elif hasattr(model, 'get_booster'):
+        try:
+            booster = model.get_booster()
+            if hasattr(booster, 'feature_names') and booster.feature_names is not None:
+                expected = list(booster.feature_names)
+        except Exception:
+            pass
+
+    if expected is None and hasattr(model, 'n_features_in_'):
+        n = model.n_features_in_
+        log.info(f"Aligning by feature count: model expects {n}, data has {len(X.columns)}")
+        while len(X.columns) < n:
+            X[f'_pad_{len(X.columns)}'] = 0
+        if len(X.columns) > n:
+            X = X.iloc[:, :n]
+        return X
+
+    if expected is None:
+        log.warning("Could not determine expected features — using data as-is")
+        return X
+
+    log.info(f"Aligning features: model expects {len(expected)}, data has {len(X.columns)}")
+    for col in set(expected) - set(X.columns):
+        X[col] = 0
+    X = X.drop(columns=list(set(X.columns) - set(expected)), errors='ignore')
+    return X[expected]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Batch 0 baseline for experiment report")
+    parser.add_argument("--s3-bucket-name", required=True)
+    parser.add_argument("--mlflow-tracking-uri", required=True)
+    args = parser.parse_args()
+
+    mlflow.set_tracking_uri(args.mlflow_tracking_uri)
+    client = MlflowClient(args.mlflow_tracking_uri)
+    s3 = boto3.client('s3')
+
+    # 1. Load production model
+    model, model_version = load_production_model(client)
+    log.info(f"Production model type: {type(model).__name__}")
+
+    # 2. Load initial_test data
+    test_df = load_test_data(s3, args.s3_bucket_name)
+    log.info(f"Test data shape: {test_df.shape}")
+
+    # 3. Feature engineering + alignment
+    X, y = prepare_features(test_df)
+    X = align_features(X, model)
+    log.info(f"Prepared features: X={X.shape}, y={y.shape}")
+
+    # 4. Predict and compute metrics
+    pred_proba = model.predict_proba(X)[:, 1]
+    pred = (pred_proba > 0.5).astype(int)
+
+    auc = roc_auc_score(y, pred_proba)
+    precision, recall, f1, _ = precision_recall_fscore_support(y, pred, average='binary', zero_division=0)
+    fpr, tpr, thresholds = roc_curve(y, pred_proba)
+
+    log.info(f"Baseline metrics — AUC: {auc:.3f}, F1: {f1:.3f}, Precision: {precision:.3f}, Recall: {recall:.3f}")
+
+    # 5. Log quality gate run (Batch 0)
+    mlflow.set_experiment(TRAINING_EXPERIMENT)
+    with mlflow.start_run(run_name="quality_gate_batch_0") as run:
+        mlflow.log_param("batch_number", 0)
+        mlflow.log_param("test_set_used", "initial_test")
+        mlflow.log_param("model_type", type(model).__name__)
+        mlflow.set_tag("quality_gate", "True")
+        mlflow.set_tag("decision", "BASELINE")
+
+        # Log as both new_* and prod_* (baseline: same model)
+        mlflow.log_metric("new_auc_test", auc)
+        mlflow.log_metric("new_f1_test", f1)
+        mlflow.log_metric("new_precision_test", precision)
+        mlflow.log_metric("new_recall_test", recall)
+        mlflow.log_metric("prod_auc_test", auc)
+        mlflow.log_metric("prod_f1_test", f1)
+        mlflow.log_metric("prod_precision_test", precision)
+        mlflow.log_metric("prod_recall_test", recall)
+        mlflow.log_metric("auc_improvement", 0.0)
+        mlflow.log_metric("f1_improvement", 0.0)
+
+        # ROC curve artifact
+        roc_data = {
+            'fpr': fpr.tolist(),
+            'tpr': tpr.tolist(),
+            'thresholds': thresholds.tolist(),
+            'auc': auc,
+        }
+        roc_path = '/tmp/roc_curve_production.json'
+        with open(roc_path, 'w') as f:
+            json.dump(roc_data, f)
+        mlflow.log_artifact(roc_path, artifact_path='roc_curves')
+
+        log.info(f"Logged quality gate run: {run.info.run_id}")
+
+    # 6. Log drift monitoring run (Batch 0 = no drift by definition)
+    mlflow.set_experiment(DRIFT_EXPERIMENT)
+    with mlflow.start_run(run_name="drift_batch_0") as run:
+        mlflow.log_param("batch_number", 0)
+        mlflow.log_metric("drift_share", 0.0)
+        mlflow.log_metric("n_drifted_columns", 0)
+        mlflow.log_metric("n_total_columns", 0)
+        mlflow.log_metric("dataset_drift", 0.0)
+        log.info(f"Logged drift run: {run.info.run_id}")
+
+    log.info("Baseline creation complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/drift_dashboard.py
+++ b/scripts/drift_dashboard.py
@@ -1,39 +1,45 @@
 #!/usr/bin/env python3
 """
-Health Predict - Comprehensive Monitoring Dashboard
+Health Predict — Continuous Improvement Experiment Report
 
-Streamlit dashboard pulling real data from MLflow and the live API,
-covering drift detection, model performance, training history,
-and deployment status.
+A vertical-scroll dashboard that tells the story of feeding 5 batches of data
+through an automated drift-detection and retraining pipeline.
 
 Usage:
     streamlit run scripts/drift_dashboard.py --server.port=8501
 """
 
-import streamlit as st
-import pandas as pd
-import plotly.graph_objects as go
-import mlflow
-from mlflow.tracking import MlflowClient
-import requests
-from datetime import datetime
+import json
 import os
+import logging
 import warnings
 
+import mlflow
+from mlflow.tracking import MlflowClient
+import pandas as pd
+import plotly.graph_objects as go
+import requests
+import streamlit as st
+
 warnings.filterwarnings("ignore")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Page config
 # ---------------------------------------------------------------------------
 st.set_page_config(
-    page_title="Health Predict - Monitoring Dashboard",
+    page_title="Health Predict — Experiment Report",
     page_icon="🏥",
     layout="wide",
-    initial_sidebar_state="expanded",
+    initial_sidebar_state="collapsed",
 )
 
 DRIFT_THRESHOLD = 0.30
-REGRESSION_THRESHOLD = -0.02
 MODEL_NAME = "HealthPredictModel"
 DRIFT_EXPERIMENT = "HealthPredict_Drift_Monitoring"
 TRAINING_EXPERIMENT = "HealthPredict_Training_HPO_Airflow"
@@ -43,580 +49,464 @@ TRAINING_EXPERIMENT = "HealthPredict_Training_HPO_Airflow"
 # ---------------------------------------------------------------------------
 
 
-@st.cache_data(ttl=60)
-def load_drift_data(tracking_uri: str) -> pd.DataFrame:
-    """Load drift monitoring runs from MLflow."""
+def _col(df: pd.DataFrame, prefix: str, name: str, default=None):
+    """Return column values, trying prefixed and unprefixed names."""
+    for candidate in [f"{prefix}{name}", name]:
+        if candidate in df.columns:
+            return df[candidate]
+    if default is not None:
+        return pd.Series([default] * len(df), index=df.index)
+    return pd.Series([None] * len(df), index=df.index)
+
+
+@st.cache_data(ttl=30)
+def get_latest_per_batch(tracking_uri: str, experiment_name: str, filter_string: str = None) -> pd.DataFrame:
+    """Query MLflow and return only the most recent run per batch number."""
     try:
         mlflow.set_tracking_uri(tracking_uri)
-        experiment = mlflow.get_experiment_by_name(DRIFT_EXPERIMENT)
+        experiment = mlflow.get_experiment_by_name(experiment_name)
         if experiment is None:
+            logger.warning(f"Experiment '{experiment_name}' not found")
             return pd.DataFrame()
+
         runs = mlflow.search_runs(
             experiment_ids=[experiment.experiment_id],
+            filter_string=filter_string,
             order_by=["start_time DESC"],
-            max_results=100,
+            max_results=200,
         )
         if runs.empty:
-            return pd.DataFrame()
-        return runs
-    except Exception:
-        return pd.DataFrame()
+            return runs
 
-
-@st.cache_data(ttl=60)
-def load_training_data(tracking_uri: str) -> pd.DataFrame:
-    """Load quality-gate runs (those with new_auc_test metric) from the training experiment."""
-    try:
-        mlflow.set_tracking_uri(tracking_uri)
-        experiment = mlflow.get_experiment_by_name(TRAINING_EXPERIMENT)
-        if experiment is None:
-            return pd.DataFrame()
-        runs = mlflow.search_runs(
-            experiment_ids=[experiment.experiment_id],
-            filter_string="metrics.new_auc_test > 0",
-            order_by=["start_time DESC"],
-            max_results=100,
+        runs["batch"] = pd.to_numeric(
+            runs.get("params.batch_number", pd.Series(dtype=float)), errors="coerce"
         )
-        if runs.empty:
-            return pd.DataFrame()
-        return runs
-    except Exception:
-        return pd.DataFrame()
-
-
-@st.cache_data(ttl=60)
-def load_hpo_trials(tracking_uri: str, ref_run_id: str) -> pd.DataFrame:
-    """Load HPO trial runs from the same pipeline execution as *ref_run_id*.
-
-    The training script creates top-level (not nested) HPO trial runs, so we
-    identify them by finding all ``hpo_trial`` runs whose start time falls
-    within a short window before the reference run (quality gate or best-model
-    run), since HPO trials run just before the evaluation step.
-    """
-    try:
-        mlflow.set_tracking_uri(tracking_uri)
-        client = mlflow.tracking.MlflowClient()
-        experiment = mlflow.get_experiment_by_name(TRAINING_EXPERIMENT)
-        if experiment is None:
-            return pd.DataFrame()
-
-        # Look up the reference run's start time
-        ref_run = client.get_run(ref_run_id)
-        ref_start_ms = ref_run.info.start_time  # epoch milliseconds
-
-        # HPO trials run before the quality gate; search 10 min before to 2 min after
-        start_ms = ref_start_ms - 10 * 60 * 1000
-        end_ms = ref_start_ms + 2 * 60 * 1000
-
-        runs = mlflow.search_runs(
-            experiment_ids=[experiment.experiment_id],
-            filter_string=(
-                f"tags.hpo_trial = 'True'"
-                f" and attributes.start_time >= {start_ms}"
-                f" and attributes.start_time <= {end_ms}"
-            ),
-            order_by=["metrics.val_roc_auc_score DESC"],
-            max_results=50,
+        runs = runs.dropna(subset=["batch"])
+        runs = runs.sort_values("start_time", ascending=False).drop_duplicates(
+            subset=["batch"], keep="first"
         )
-        return runs
-    except Exception:
+        return runs.sort_values("batch").reset_index(drop=True)
+    except Exception as e:
+        logger.error(f"Failed to load runs from '{experiment_name}': {e}")
         return pd.DataFrame()
 
 
-@st.cache_data(ttl=60)
-def load_model_registry(tracking_uri: str) -> pd.DataFrame:
-    """Load model version history from the MLflow model registry."""
+@st.cache_data(ttl=30)
+def load_model_registry(tracking_uri: str) -> dict:
+    """Return info about the current Production model."""
     try:
         mlflow.set_tracking_uri(tracking_uri)
         client = MlflowClient(tracking_uri)
-        versions = client.search_model_versions(f"name='{MODEL_NAME}'")
+        versions = client.get_latest_versions(MODEL_NAME, stages=["Production"])
         if not versions:
-            return pd.DataFrame()
-        rows = []
-        for v in versions:
-            rows.append(
-                {
-                    "version": int(v.version),
-                    "stage": v.current_stage,
-                    "created": datetime.fromtimestamp(v.creation_timestamp / 1000).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    ),
-                    "run_id": v.run_id,
-                    "status": v.status,
-                    "description": v.description or "",
-                }
-            )
-        return pd.DataFrame(rows).sort_values("version", ascending=False)
-    except Exception:
-        return pd.DataFrame()
+            return {}
+        v = versions[0]
+        return {
+            "version": int(v.version),
+            "stage": v.current_stage,
+            "run_id": v.run_id,
+        }
+    except Exception as e:
+        logger.error(f"Failed to load model registry: {e}")
+        return {}
 
 
 def check_api_health(api_url: str) -> dict:
-    """Query the live prediction API for health and model info."""
-    result = {"api_status": "unavailable", "model_version": "N/A", "model_stage": "N/A", "loaded_at": "N/A"}
+    """Quick API health check."""
+    result = {"status": "not_configured", "model_version": None}
+    if not api_url:
+        return result
     try:
-        r = requests.get(f"{api_url}/health", timeout=3)
-        if r.status_code == 200:
-            result["api_status"] = "healthy"
-    except Exception:
-        pass
+        r = requests.get(f"{api_url}/health", timeout=5)
+        result["status"] = "healthy" if r.status_code == 200 else f"HTTP {r.status_code}"
+    except requests.Timeout:
+        result["status"] = "timeout"
+        return result
+    except requests.ConnectionError:
+        result["status"] = "unreachable"
+        return result
+    except Exception as e:
+        result["status"] = str(e)[:50]
+        return result
+
     try:
-        r = requests.get(f"{api_url}/model-info", timeout=3)
+        r = requests.get(f"{api_url}/model-info", timeout=5)
         if r.status_code == 200:
             info = r.json()
-            result["model_version"] = info.get("model_version", "N/A")
-            result["model_stage"] = info.get("model_stage", "N/A")
-            result["loaded_at"] = info.get("loaded_at", "N/A")
+            result["model_version"] = info.get("model_version")
     except Exception:
         pass
     return result
 
 
-# ---------------------------------------------------------------------------
-# Helper: extract param/metric from MLflow DataFrame
-# ---------------------------------------------------------------------------
+def load_roc_curves(tracking_uri: str, run_id: str) -> dict:
+    """Download ROC curve JSON artifacts for a run. Returns dict with 'production' and/or 'new' keys."""
+    curves = {}
+    try:
+        client = MlflowClient(tracking_uri)
+        artifact_dir = client.download_artifacts(run_id, "roc_curves")
+        for name in ["production", "new"]:
+            path = os.path.join(artifact_dir, f"roc_curve_{name}.json")
+            if os.path.exists(path):
+                with open(path) as f:
+                    curves[name] = json.load(f)
+    except Exception as e:
+        logger.debug(f"Could not load ROC curves for {run_id}: {e}")
+    return curves
 
-def _col(df: pd.DataFrame, prefix: str, name: str):
-    """Return column values, trying prefixed and unprefixed names."""
-    for candidate in [f"{prefix}{name}", name]:
-        if candidate in df.columns:
-            return df[candidate]
-    return pd.Series([None] * len(df))
-
 
 # ---------------------------------------------------------------------------
-# Sidebar
+# Sidebar (minimal)
 # ---------------------------------------------------------------------------
-
-st.sidebar.header("Configuration")
 mlflow_uri = st.sidebar.text_input(
     "MLflow Tracking URI",
     value=os.getenv("MLFLOW_TRACKING_URI", "http://mlflow:5000"),
 )
 api_url = st.sidebar.text_input(
     "Prediction API URL",
-    value=os.getenv("API_URL", "http://health-predict-api:8000"),
-    help="The base URL for the deployed prediction API (K8s service or minikube IP).",
+    value=os.getenv("API_URL", ""),
 )
 if st.sidebar.button("Refresh Data"):
     st.cache_data.clear()
+    st.rerun()
 
 st.sidebar.markdown("---")
 st.sidebar.markdown(
     f"**Drift threshold:** {DRIFT_THRESHOLD}  \n"
-    f"**Regression threshold:** {REGRESSION_THRESHOLD}"
+    f"[MLflow UI]({mlflow_uri.replace('mlflow:5000','localhost:5000')})  \n"
+    f"[Airflow UI](http://localhost:8080)"
 )
-
-# ---------------------------------------------------------------------------
-# Title
-# ---------------------------------------------------------------------------
-st.title("Health Predict - Monitoring Dashboard")
 
 # ---------------------------------------------------------------------------
 # Load data
 # ---------------------------------------------------------------------------
-drift_df = load_drift_data(mlflow_uri)
-training_df = load_training_data(mlflow_uri)
-registry_df = load_model_registry(mlflow_uri)
+drift_runs = get_latest_per_batch(mlflow_uri, DRIFT_EXPERIMENT)
+quality_runs = get_latest_per_batch(
+    mlflow_uri, TRAINING_EXPERIMENT, filter_string="metrics.new_auc_test > 0"
+)
+prod_model = load_model_registry(mlflow_uri)
 api_info = check_api_health(api_url)
 
-# ---------------------------------------------------------------------------
-# 1. System Status Bar
-# ---------------------------------------------------------------------------
-st.header("System Status")
-c1, c2, c3, c4 = st.columns(4)
+# Build a unified per-batch dataframe
+batches = set()
+if not drift_runs.empty:
+    batches.update(drift_runs["batch"].astype(int).tolist())
+if not quality_runs.empty:
+    batches.update(quality_runs["batch"].astype(int).tolist())
+batches = sorted(batches)
 
+rows = []
+for b in batches:
+    row = {"batch": b}
+
+    # Drift info
+    if not drift_runs.empty:
+        d = drift_runs[drift_runs["batch"] == b]
+        if not d.empty:
+            row["drift_share"] = pd.to_numeric(_col(d, "metrics.", "drift_share").iloc[0], errors="coerce")
+            row["n_drifted"] = pd.to_numeric(_col(d, "metrics.", "n_drifted_columns").iloc[0], errors="coerce")
+
+    # Quality gate info
+    if not quality_runs.empty:
+        q = quality_runs[quality_runs["batch"] == b]
+        if not q.empty:
+            row["run_id"] = q.iloc[0].get("run_id")
+            row["decision"] = _col(q, "tags.", "decision").iloc[0]
+            row["new_auc"] = pd.to_numeric(_col(q, "metrics.", "new_auc_test").iloc[0], errors="coerce")
+            row["new_f1"] = pd.to_numeric(_col(q, "metrics.", "new_f1_test").iloc[0], errors="coerce")
+            row["new_precision"] = pd.to_numeric(_col(q, "metrics.", "new_precision_test").iloc[0], errors="coerce")
+            row["new_recall"] = pd.to_numeric(_col(q, "metrics.", "new_recall_test").iloc[0], errors="coerce")
+            row["prod_auc"] = pd.to_numeric(_col(q, "metrics.", "prod_auc_test").iloc[0], errors="coerce")
+            row["prod_f1"] = pd.to_numeric(_col(q, "metrics.", "prod_f1_test").iloc[0], errors="coerce")
+            row["prod_precision"] = pd.to_numeric(_col(q, "metrics.", "prod_precision_test").iloc[0], errors="coerce")
+            row["prod_recall"] = pd.to_numeric(_col(q, "metrics.", "prod_recall_test").iloc[0], errors="coerce")
+            row["auc_improvement"] = pd.to_numeric(_col(q, "metrics.", "auc_improvement").iloc[0], errors="coerce")
+            row["f1_improvement"] = pd.to_numeric(_col(q, "metrics.", "f1_improvement").iloc[0], errors="coerce")
+
+    # Infer decision when tag is missing (retrain-path runs don't set it)
+    decision = row.get("decision")
+    if decision is None or (isinstance(decision, float) and pd.isna(decision)):
+        auc_imp = row.get("auc_improvement")
+        new_a = row.get("new_auc")
+        prod_a = row.get("prod_auc")
+        if pd.notna(auc_imp) and abs(auc_imp) > 0.001:
+            row["decision"] = "DEPLOY" if auc_imp >= 0 else "DEPLOY_REFRESH"
+        elif pd.notna(new_a) and pd.notna(prod_a) and abs(new_a - prod_a) > 0.001:
+            row["decision"] = "DEPLOY" if new_a >= prod_a else "DEPLOY_REFRESH"
+
+    rows.append(row)
+
+report_df = pd.DataFrame(rows)
+
+# ---------------------------------------------------------------------------
+# HERO SECTION
+# ---------------------------------------------------------------------------
+st.markdown("# Health Predict — Continuous Improvement Experiment")
+st.markdown(
+    "An automated MLOps system that monitors incoming patient data for distribution drift, "
+    "retrains models when drift is detected, and deploys improved models — all without manual intervention."
+)
+
+c1, c2, c3 = st.columns(3)
 with c1:
-    is_healthy = api_info["api_status"] == "healthy"
-    st.metric("API Status", "Healthy" if is_healthy else "Unavailable")
-
+    if prod_model:
+        st.metric("Production Model", f"v{prod_model['version']}")
+    elif api_info.get("model_version"):
+        st.metric("Production Model", f"v{api_info['model_version']}")
+    else:
+        st.metric("Production Model", "—")
 with c2:
-    st.metric("Current Model", f"v{api_info['model_version']} ({api_info['model_stage']})")
-
+    st.metric("Batches Processed", len(batches))
 with c3:
-    if not drift_df.empty:
-        latest_drift_share = _col(drift_df, "metrics.", "drift_share").iloc[0]
-        try:
-            latest_drift_share = float(latest_drift_share)
-            st.metric("Latest Drift Share", f"{latest_drift_share:.3f}")
-        except (TypeError, ValueError):
-            st.metric("Latest Drift Share", "N/A")
-    else:
-        st.metric("Latest Drift Share", "N/A")
-
-with c4:
-    if not drift_df.empty:
-        try:
-            gate = "RETRAIN" if float(latest_drift_share) >= DRIFT_THRESHOLD else "SKIP"
-        except Exception:
-            gate = "N/A"
-        st.metric("Drift Gate", gate)
-    else:
-        st.metric("Drift Gate", "N/A")
+    retrain_count = 0
+    if not report_df.empty and "decision" in report_df.columns:
+        retrain_count = report_df["decision"].isin(["DEPLOY", "DEPLOY_REFRESH"]).sum()
+    st.metric("Retraining Events", int(retrain_count))
 
 st.markdown("---")
 
 # ---------------------------------------------------------------------------
-# Tabs
+# EXPERIMENT SUMMARY
 # ---------------------------------------------------------------------------
-tab_drift, tab_perf, tab_training, tab_registry = st.tabs(
-    ["Drift Monitoring", "Model Performance", "Training History", "Model Registry"]
-)
+if report_df.empty:
+    st.info("No experiment data found. Run the pipeline and/or the baseline script first.")
+    st.stop()
+
+st.markdown("## Experiment Summary")
+
+# Drift Progression Chart
+if "drift_share" in report_df.columns and report_df["drift_share"].notna().any():
+    drift_plot = report_df.dropna(subset=["drift_share"])
+    colors = ["#e74c3c" if v >= DRIFT_THRESHOLD else "#27ae60" for v in drift_plot["drift_share"]]
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            x=drift_plot["batch"].astype(int).astype(str),
+            y=drift_plot["drift_share"],
+            marker_color=colors,
+            text=[f"{v:.2f}" for v in drift_plot["drift_share"]],
+            textposition="outside",
+        )
+    )
+    fig.add_hline(
+        y=DRIFT_THRESHOLD,
+        line_dash="dash",
+        line_color="orange",
+        annotation_text=f"Retrain Threshold ({DRIFT_THRESHOLD})",
+    )
+    fig.update_layout(
+        title="Drift Progression Across Batches",
+        xaxis_title="Batch",
+        yaxis_title="Drift Share",
+        yaxis_range=[0, max(drift_plot["drift_share"].max() * 1.3, 0.5)],
+        height=380,
+        showlegend=False,
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+# Metrics Summary Table
+st.markdown("### Metrics Summary")
+
+table_rows = []
+for _, r in report_df.iterrows():
+    b = int(r["batch"])
+    decision = r.get("decision", "—") or "—"
+    drift = r.get("drift_share")
+    drift_str = f"{drift:.2f}" if pd.notna(drift) else "—"
+
+    retrained = "—"
+    if decision in ("DEPLOY", "DEPLOY_REFRESH"):
+        retrained = "Yes"
+    elif decision == "SKIP_NO_DRIFT":
+        retrained = "No"
+    elif decision == "BASELINE":
+        retrained = "—"
+    elif decision == "SKIP":
+        retrained = "Skipped"
+
+    prod_auc_val = r.get("prod_auc")
+    prod_f1_val = r.get("prod_f1")
+    new_auc_val = r.get("new_auc")
+    new_f1_val = r.get("new_f1")
+
+    # For non-retrained batches, new_* == prod_* (same model), so only show once
+    show_new = decision in ("DEPLOY", "DEPLOY_REFRESH")
+
+    table_rows.append({
+        "Batch": b,
+        "Drift Share": drift_str,
+        "Retrained?": retrained,
+        "Decision": decision,
+        "Prod AUC": f"{prod_auc_val:.3f}" if pd.notna(prod_auc_val) else "—",
+        "Prod F1": f"{prod_f1_val:.3f}" if pd.notna(prod_f1_val) else "—",
+        "New AUC": f"{new_auc_val:.3f}" if show_new and pd.notna(new_auc_val) else "—",
+        "New F1": f"{new_f1_val:.3f}" if show_new and pd.notna(new_f1_val) else "—",
+    })
+
+st.dataframe(pd.DataFrame(table_rows), use_container_width=True, hide_index=True)
+
+st.markdown("---")
 
 # ---------------------------------------------------------------------------
-# 2. Drift Monitoring
+# PER-BATCH JOURNEY
 # ---------------------------------------------------------------------------
-with tab_drift:
-    st.subheader("Drift Monitoring")
-    if drift_df.empty:
-        st.info("No drift monitoring data available. Run the pipeline to generate drift metrics.")
+st.markdown("## Batch-by-Batch Journey")
+
+for _, r in report_df.iterrows():
+    b = int(r["batch"])
+    decision = r.get("decision", None) or "—"
+    drift = r.get("drift_share")
+    n_drifted = r.get("n_drifted")
+    run_id = r.get("run_id")
+
+    # Header with badge
+    if decision == "BASELINE":
+        badge = ":blue[Baseline]"
+        header_suffix = "Initial Training — Baseline"
+    elif decision == "SKIP_NO_DRIFT":
+        badge = ":green[No Drift]"
+        header_suffix = "No Drift Detected"
+    elif decision in ("DEPLOY", "DEPLOY_REFRESH"):
+        badge = ":red[Drift Detected → Retrained]"
+        header_suffix = "Drift Detected — Retrained"
+    elif decision == "SKIP":
+        badge = ":orange[Drift Detected — Regression]"
+        header_suffix = "Drift Detected — Deployment Skipped"
     else:
-        # Extract relevant columns
-        batch_col = _col(drift_df, "params.", "batch_number")
-        drift_share_col = _col(drift_df, "metrics.", "drift_share")
-        n_drifted_col = _col(drift_df, "metrics.", "n_drifted_columns")
-        dataset_drift_col = _col(drift_df, "metrics.", "dataset_drift")
+        badge = ""
+        header_suffix = ""
 
-        plot_df = pd.DataFrame(
-            {
-                "batch": pd.to_numeric(batch_col, errors="coerce"),
-                "drift_share": pd.to_numeric(drift_share_col, errors="coerce"),
-                "n_drifted": pd.to_numeric(n_drifted_col, errors="coerce"),
-                "dataset_drift": dataset_drift_col,
-                "timestamp": drift_df["start_time"] if "start_time" in drift_df.columns else None,
-            }
-        ).dropna(subset=["batch", "drift_share"]).sort_values("batch")
+    st.markdown(f"### Batch {b}: {header_suffix} {badge}")
 
-        if not plot_df.empty:
-            # Drift share bar chart
-            st.markdown("#### Drift Share by Batch")
-            colors = ["red" if v >= DRIFT_THRESHOLD else "green" for v in plot_df["drift_share"]]
-            fig_share = go.Figure()
-            fig_share.add_trace(
-                go.Bar(
-                    x=plot_df["batch"].astype(int).astype(str),
-                    y=plot_df["drift_share"],
-                    marker_color=colors,
-                    name="Drift Share",
-                )
-            )
-            fig_share.add_hline(
-                y=DRIFT_THRESHOLD,
-                line_dash="dash",
-                line_color="orange",
-                annotation_text=f"Threshold ({DRIFT_THRESHOLD})",
-            )
-            fig_share.update_layout(
-                xaxis_title="Batch",
-                yaxis_title="Drift Share",
-                height=400,
-            )
-            st.plotly_chart(fig_share, width="stretch")
+    # Drift info (not for baseline)
+    if b > 0 and pd.notna(drift):
+        above = "above" if drift >= DRIFT_THRESHOLD else "below"
+        st.markdown(
+            f"**Drift share:** {drift:.3f} ({above} {DRIFT_THRESHOLD} threshold) "
+            f"&nbsp;|&nbsp; **Drifted features:** {int(n_drifted) if pd.notna(n_drifted) else '—'}"
+        )
+    elif b == 0:
+        st.markdown("*Baseline — no drift analysis (this is the reference point)*")
 
-            # Drifted features count
-            st.markdown("#### Drifted Features Count by Batch")
-            fig_count = go.Figure()
-            fig_count.add_trace(
-                go.Bar(
-                    x=plot_df["batch"].astype(int).astype(str),
-                    y=plot_df["n_drifted"],
-                    marker_color="steelblue",
-                    name="Drifted Columns",
-                )
-            )
-            fig_count.update_layout(
-                xaxis_title="Batch",
-                yaxis_title="Drifted Columns",
-                height=350,
-            )
-            st.plotly_chart(fig_count, width="stretch")
+    # Decision
+    if decision not in ("BASELINE", "—"):
+        st.markdown(f"**Decision:** `{decision}`")
 
-            # Detail table
-            st.markdown("#### Drift Detail Table")
-            detail = plot_df[["batch", "drift_share", "n_drifted", "dataset_drift", "timestamp"]].copy()
-            detail["batch"] = detail["batch"].astype(int)
-            detail.columns = ["Batch", "Drift Share", "Drifted Columns", "Dataset Drift", "Timestamp"]
-            st.dataframe(detail, width="stretch", hide_index=True)
-        else:
-            st.warning("Drift data could not be parsed.")
+    # Metrics
+    prod_auc_val = r.get("prod_auc")
+    prod_f1_val = r.get("prod_f1")
+    prod_prec = r.get("prod_precision")
+    prod_rec = r.get("prod_recall")
+    new_auc_val = r.get("new_auc")
+    new_f1_val = r.get("new_f1")
+    new_prec = r.get("new_precision")
+    new_rec = r.get("new_recall")
+    auc_imp = r.get("auc_improvement")
 
-# ---------------------------------------------------------------------------
-# 3. Model Performance
-# ---------------------------------------------------------------------------
-with tab_perf:
-    st.subheader("Model Performance")
-    if training_df.empty:
-        st.info("No quality-gate evaluation data available. Run the pipeline with deployment to generate metrics.")
+    retrained = decision in ("DEPLOY", "DEPLOY_REFRESH")
+
+    if retrained:
+        # Show both prod and new model side by side
+        left, right = st.columns(2)
+        with left:
+            st.markdown("**Production Model (before)**")
+            m1, m2, m3, m4 = st.columns(4)
+            m1.metric("AUC", f"{prod_auc_val:.3f}" if pd.notna(prod_auc_val) else "—")
+            m2.metric("F1", f"{prod_f1_val:.3f}" if pd.notna(prod_f1_val) else "—")
+            m3.metric("Precision", f"{prod_prec:.3f}" if pd.notna(prod_prec) else "—")
+            m4.metric("Recall", f"{prod_rec:.3f}" if pd.notna(prod_rec) else "—")
+        with right:
+            st.markdown("**New Model (after)**")
+            m1, m2, m3, m4 = st.columns(4)
+            delta_auc = f"{auc_imp:+.3f}" if pd.notna(auc_imp) else None
+            m1.metric("AUC", f"{new_auc_val:.3f}" if pd.notna(new_auc_val) else "—", delta=delta_auc)
+            m2.metric("F1", f"{new_f1_val:.3f}" if pd.notna(new_f1_val) else "—")
+            m3.metric("Precision", f"{new_prec:.3f}" if pd.notna(new_prec) else "—")
+            m4.metric("Recall", f"{new_rec:.3f}" if pd.notna(new_rec) else "—")
     else:
-        batch_col = _col(training_df, "params.", "batch_number")
-        decision_tag = _col(training_df, "tags.", "decision")
-        new_auc = _col(training_df, "metrics.", "new_auc_test")
-        new_f1 = _col(training_df, "metrics.", "new_f1_test")
-        prod_auc = _col(training_df, "metrics.", "prod_auc_test")
-        auc_imp = _col(training_df, "metrics.", "auc_improvement")
-        f1_imp = _col(training_df, "metrics.", "f1_improvement")
+        # Show prod metrics only (or baseline metrics)
+        label = "Baseline Metrics" if decision == "BASELINE" else "Production Model on This Batch"
+        st.markdown(f"**{label}**")
+        m1, m2, m3, m4 = st.columns(4)
+        # For non-retrained batches, new_* == prod_* (same model evaluated)
+        auc_show = prod_auc_val if pd.notna(prod_auc_val) else new_auc_val
+        f1_show = prod_f1_val if pd.notna(prod_f1_val) else new_f1_val
+        prec_show = prod_prec if pd.notna(prod_prec) else new_prec
+        rec_show = prod_rec if pd.notna(prod_rec) else new_rec
+        m1.metric("AUC", f"{auc_show:.3f}" if pd.notna(auc_show) else "—")
+        m2.metric("F1", f"{f1_show:.3f}" if pd.notna(f1_show) else "—")
+        m3.metric("Precision", f"{prec_show:.3f}" if pd.notna(prec_show) else "—")
+        m4.metric("Recall", f"{rec_show:.3f}" if pd.notna(rec_show) else "—")
 
-        perf_df = pd.DataFrame(
-            {
-                "batch": pd.to_numeric(batch_col, errors="coerce"),
-                "decision": decision_tag,
-                "new_auc": pd.to_numeric(new_auc, errors="coerce"),
-                "new_f1": pd.to_numeric(new_f1, errors="coerce"),
-                "prod_auc": pd.to_numeric(prod_auc, errors="coerce"),
-                "auc_improvement": pd.to_numeric(auc_imp, errors="coerce"),
-                "f1_improvement": pd.to_numeric(f1_imp, errors="coerce"),
-                "run_id": training_df["run_id"],
-            }
-        ).dropna(subset=["batch", "new_auc"]).sort_values("batch")
-
-        if not perf_df.empty:
-            # AUC trend
-            st.markdown("#### AUC Trend Across Batches")
-            fig_auc = go.Figure()
-            fig_auc.add_trace(
-                go.Scatter(
-                    x=perf_df["batch"].astype(int).astype(str),
-                    y=perf_df["new_auc"],
-                    mode="lines+markers",
-                    name="New Model AUC",
-                    line=dict(color="blue"),
-                )
-            )
-            if perf_df["prod_auc"].notna().any():
-                fig_auc.add_trace(
-                    go.Scatter(
-                        x=perf_df["batch"].astype(int).astype(str),
-                        y=perf_df["prod_auc"],
-                        mode="lines+markers",
-                        name="Production AUC",
-                        line=dict(color="gray", dash="dot"),
-                    )
-                )
-            fig_auc.update_layout(xaxis_title="Batch", yaxis_title="AUC", height=400)
-            st.plotly_chart(fig_auc, width="stretch")
-
-            # AUC improvement bar chart
-            st.markdown("#### AUC Improvement per Batch")
-            imp_colors = [
-                "green" if v >= 0 else ("red" if v < REGRESSION_THRESHOLD else "orange")
-                for v in perf_df["auc_improvement"].fillna(0)
-            ]
-            fig_imp = go.Figure()
-            fig_imp.add_trace(
-                go.Bar(
-                    x=perf_df["batch"].astype(int).astype(str),
-                    y=perf_df["auc_improvement"],
-                    marker_color=imp_colors,
-                    name="AUC Improvement",
-                )
-            )
-            fig_imp.add_hline(
-                y=REGRESSION_THRESHOLD,
-                line_dash="dash",
-                line_color="red",
-                annotation_text=f"Regression Threshold ({REGRESSION_THRESHOLD})",
-            )
-            fig_imp.add_hline(y=0, line_color="black", line_width=0.5)
-            fig_imp.update_layout(xaxis_title="Batch", yaxis_title="AUC Improvement", height=350)
-            st.plotly_chart(fig_imp, width="stretch")
-
-            # Metrics comparison table
-            st.markdown("#### Metrics Comparison Table")
-            comp = perf_df[["batch", "decision", "new_auc", "new_f1", "prod_auc", "auc_improvement", "f1_improvement"]].copy()
-            comp["batch"] = comp["batch"].astype(int)
-            comp.columns = [
-                "Batch",
-                "Decision",
-                "New AUC",
-                "New F1",
-                "Prod AUC",
-                "AUC Improvement",
-                "F1 Improvement",
-            ]
-            st.dataframe(comp, width="stretch", hide_index=True)
-
-            # ROC Curve Visualization
-            st.markdown("### ROC Curves by Batch")
-            st.markdown("Shows true positive rate vs false positive rate for each batch's model.")
-
-            # Let user select batch to visualize
-            selected_batch = st.selectbox(
-                "Select batch to view ROC curve:",
-                options=sorted(perf_df['batch'].unique()),
-                format_func=lambda x: f"Batch {int(x)}"
-            )
-
-            # Get the quality gate run for selected batch
-            batch_mask = perf_df['batch'] == selected_batch
-            if batch_mask.any():
-                run_id = perf_df[batch_mask].iloc[0]['run_id']
-
-                # Download ROC curve artifacts from MLflow
-                client = MlflowClient(mlflow_uri)
-                try:
-                    import json
-                    artifact_path = client.download_artifacts(run_id, "roc_curves")
-
-                    fig_roc = go.Figure()
-
-                    # Load production model ROC curve (exists for both SKIP_NO_DRIFT and DEPLOY)
-                    try:
-                        with open(f"{artifact_path}/roc_curve_production.json", 'r') as f:
-                            roc_prod = json.load(f)
-
-                        fig_roc.add_trace(go.Scatter(
-                            x=roc_prod['fpr'],
-                            y=roc_prod['tpr'],
-                            mode='lines',
-                            name=f"Production Model (AUC={roc_prod['auc']:.3f})",
-                            line=dict(color='blue', width=2),
-                        ))
-                    except Exception:
-                        pass
-
-                    # Load new model ROC curve (exists for DEPLOY runs only)
-                    try:
-                        with open(f"{artifact_path}/roc_curve_new.json", 'r') as f:
-                            roc_new = json.load(f)
-
-                        fig_roc.add_trace(go.Scatter(
-                            x=roc_new['fpr'],
-                            y=roc_new['tpr'],
-                            mode='lines',
-                            name=f"New Model (AUC={roc_new['auc']:.3f})",
-                            line=dict(color='green', width=2),
-                        ))
-                    except Exception:
-                        pass
-
-                    # Add diagonal reference line (random classifier)
+    # ROC Curve (expandable)
+    if run_id and pd.notna(run_id):
+        with st.expander("View ROC Curve"):
+            curves = load_roc_curves(mlflow_uri, run_id)
+            if curves:
+                fig_roc = go.Figure()
+                if "production" in curves:
+                    roc = curves["production"]
                     fig_roc.add_trace(go.Scatter(
-                        x=[0, 1],
-                        y=[0, 1],
-                        mode='lines',
-                        name='Random Classifier',
-                        line=dict(color='gray', width=1, dash='dash'),
+                        x=roc["fpr"], y=roc["tpr"], mode="lines",
+                        name=f"Production (AUC={roc['auc']:.3f})",
+                        line=dict(color="blue", width=2),
                     ))
-
-                    fig_roc.update_layout(
-                        title=f"ROC Curve - Batch {int(selected_batch)}",
-                        xaxis_title="False Positive Rate",
-                        yaxis_title="True Positive Rate",
-                        hovermode='closest',
-                        legend=dict(x=0.6, y=0.1),
-                        width=800,
-                        height=600,
-                    )
-
-                    st.plotly_chart(fig_roc, use_container_width=True)
-
-                    st.caption(
-                        "**Interpretation**: The closer the curve is to the top-left corner, "
-                        "the better the model. AUC = 1.0 is perfect, AUC = 0.5 is random guessing."
-                    )
-                except Exception as e:
-                    st.warning(f"Could not load ROC curve data: {e}")
+                if "new" in curves:
+                    roc = curves["new"]
+                    fig_roc.add_trace(go.Scatter(
+                        x=roc["fpr"], y=roc["tpr"], mode="lines",
+                        name=f"New Model (AUC={roc['auc']:.3f})",
+                        line=dict(color="green", width=2),
+                    ))
+                fig_roc.add_trace(go.Scatter(
+                    x=[0, 1], y=[0, 1], mode="lines",
+                    name="Random",
+                    line=dict(color="gray", width=1, dash="dash"),
+                ))
+                fig_roc.update_layout(
+                    xaxis_title="False Positive Rate",
+                    yaxis_title="True Positive Rate",
+                    legend=dict(x=0.55, y=0.1),
+                    height=450,
+                )
+                st.plotly_chart(fig_roc, use_container_width=True)
             else:
-                st.info(f"No ROC curve data available for batch {int(selected_batch)}")
-        else:
-            st.warning("Performance data could not be parsed.")
+                st.caption("No ROC curve artifacts available for this batch.")
+
+    st.markdown("---")
 
 # ---------------------------------------------------------------------------
-# 4. Training History
+# FINAL SUMMARY
 # ---------------------------------------------------------------------------
-with tab_training:
-    st.subheader("Training History")
-    if training_df.empty:
-        st.info("No training data available.")
-    else:
-        batch_col = _col(training_df, "params.", "batch_number")
-        batches = pd.to_numeric(batch_col, errors="coerce").dropna().unique()
-        batches = sorted([int(b) for b in batches])
+st.markdown("## Final Summary")
 
-        if batches:
-            selected_batch = st.selectbox("Select batch", batches, index=len(batches) - 1)
+starting_auc = None
+ending_auc = None
+if not report_df.empty and "new_auc" in report_df.columns:
+    first = report_df.iloc[0]
+    last = report_df.iloc[-1]
+    starting_auc = first.get("prod_auc") if pd.notna(first.get("prod_auc")) else first.get("new_auc")
+    ending_auc = last.get("new_auc") if pd.notna(last.get("new_auc")) else last.get("prod_auc")
 
-            # Find the parent run for this batch
-            batch_mask = _col(training_df, "params.", "batch_number").astype(str) == str(selected_batch)
-            batch_runs = training_df[batch_mask]
+c1, c2, c3 = st.columns(3)
+with c1:
+    st.metric("Starting AUC (Batch 0)", f"{starting_auc:.3f}" if pd.notna(starting_auc) else "—")
+with c2:
+    st.metric(
+        "Final AUC",
+        f"{ending_auc:.3f}" if pd.notna(ending_auc) else "—",
+        delta=f"{ending_auc - starting_auc:+.3f}" if pd.notna(starting_auc) and pd.notna(ending_auc) else None,
+    )
+with c3:
+    st.metric("Retraining Events", f"{int(retrain_count)} of {max(len(batches) - 1, 0)} batches")
 
-            if not batch_runs.empty:
-                # Use the quality gate run itself as time reference for finding HPO trials
-                qg_run_id = batch_runs.iloc[0]["run_id"]
-                st.markdown(f"**Quality gate run ID:** `{qg_run_id}`")
-
-                trials_df = load_hpo_trials(mlflow_uri, qg_run_id)
-                if not trials_df.empty:
-                    st.markdown("#### HPO Trials")
-                    # Select useful columns
-                    display_cols = []
-                    for col in trials_df.columns:
-                        if col.startswith("params.") and any(
-                            k in col
-                            for k in [
-                                "max_depth",
-                                "learning_rate",
-                                "n_estimators",
-                                "subsample",
-                                "colsample_bytree",
-                                "reg_alpha",
-                                "reg_lambda",
-                                "gamma",
-                                "min_child_weight",
-                                "model_type",
-                            ]
-                        ):
-                            display_cols.append(col)
-                    metric_cols = [
-                        c
-                        for c in trials_df.columns
-                        if c.startswith("metrics.") and "val_" in c
-                    ]
-                    show_cols = display_cols + metric_cols
-                    if show_cols:
-                        t = trials_df[show_cols].copy()
-                        t.columns = [c.replace("params.", "").replace("metrics.", "") for c in t.columns]
-                        st.dataframe(t, width="stretch", hide_index=True)
-                    else:
-                        st.dataframe(trials_df.head(20), width="stretch", hide_index=True)
-                else:
-                    st.info("No HPO trial (child) runs found for this batch.")
-
-            # Best model per batch summary
-            st.markdown("#### Best Model per Batch")
-            summary_rows = []
-            for b in batches:
-                mask = _col(training_df, "params.", "batch_number").astype(str) == str(b)
-                b_runs = training_df[mask]
-                if not b_runs.empty:
-                    best_auc_col = _col(b_runs, "metrics.", "new_auc_test")
-                    try:
-                        best_auc = float(best_auc_col.iloc[0])
-                    except (TypeError, ValueError):
-                        best_auc = None
-                    model_type = _col(b_runs, "params.", "model_type")
-                    mt = model_type.iloc[0] if not model_type.empty else "N/A"
-                    summary_rows.append({"Batch": int(b), "Best AUC (test)": best_auc, "Model Type": mt})
-            if summary_rows:
-                st.dataframe(pd.DataFrame(summary_rows), width="stretch", hide_index=True)
-        else:
-            st.warning("No batches found in training data.")
-
-# ---------------------------------------------------------------------------
-# 5. Model Registry
-# ---------------------------------------------------------------------------
-with tab_registry:
-    st.subheader("Model Registry")
-    if registry_df.empty:
-        st.info("No model versions found in the registry.")
-    else:
-        st.markdown(f"**Registered model:** `{MODEL_NAME}`")
-
-        # Highlight production row
-        prod = registry_df[registry_df["stage"] == "Production"]
-        if not prod.empty:
-            st.markdown("#### Current Production Model")
-            st.dataframe(prod, width="stretch", hide_index=True)
-
-        st.markdown("#### Version History")
-        st.dataframe(registry_df, width="stretch", hide_index=True)
+if pd.notna(starting_auc) and pd.notna(ending_auc) and retrain_count is not None:
+    drift_count = 0
+    if "drift_share" in report_df.columns:
+        drift_count = (report_df["drift_share"].fillna(0) >= DRIFT_THRESHOLD).sum()
+    st.markdown(
+        f"The system detected significant drift in **{int(drift_count)}** of "
+        f"**{max(len(batches) - 1, 0)}** batches and triggered **{int(retrain_count)}** retraining events, "
+        f"moving AUC from **{starting_auc:.3f}** to **{ending_auc:.3f}** "
+        f"({ending_auc - starting_auc:+.3f})."
+    )


### PR DESCRIPTION
## Summary

Transforms the monitoring dashboard from a 4-tab real-time tool into a vertical-scroll **experiment report** that tells the story of feeding 5 data batches through an automated drift-detection and retraining pipeline.

### What changed

- **Dashboard rewrite** (`scripts/drift_dashboard.py`, 792→510 lines): Single scrollable page with hero section, drift progression chart, metrics summary table, per-batch journey sections (with expandable ROC curves), and final summary
- **Baseline script** (`scripts/create_baseline.py`): Evaluates production model on initial_test.csv, logs Batch 0 to MLflow as quality gate + drift monitoring run
- **Data deduplication**: New `get_latest_per_batch()` filters to only the most recent run per batch number, eliminating historical noise from debug/repeated runs
- **Decision inference**: Handles retrain-path quality gate runs that lack the `decision` MLflow tag by inferring from `auc_improvement` metrics

### Dashboard sections

1. **Hero** — Production model version, batches processed, retraining events
2. **Experiment Summary** — Drift progression bar chart (color-coded, 0.30 threshold line) + metrics table
3. **Batch-by-Batch Journey** — Per-batch sections with drift info, decision badge, metrics (side-by-side for retrained batches), expandable ROC curves
4. **Final Summary** — Starting vs ending AUC, retraining count, narrative takeaway

### Use case shift

**Before**: Real-time ops console showing every historical run
**After**: Clean experiment report showing one story — baseline → drift detection → retraining → improvement

## Test plan

- [x] Baseline script creates Batch 0 quality gate + drift runs in MLflow
- [x] Dashboard deduplicates to latest run per batch
- [x] Dashboard renders as single scrollable page (no tabs)
- [x] Drift chart shows batches 0-5 with threshold line
- [x] Per-batch sections show correct decisions and metrics
- [x] ROC curves load in expandable sections
- [x] Container rebuilds cleanly with `docker-compose up -d --no-deps --build dashboard`